### PR TITLE
add feature to have custom channel id names

### DIFF
--- a/tv_grab_fr_telerama
+++ b/tv_grab_fr_telerama
@@ -263,6 +263,8 @@ END
 
 use warnings;
 use strict;
+
+use utf8;
 use XMLTV::Version '$Id: tv_grab_fr_telerama,v 1.35 2018/11/08 22:21:00 zubrick Exp $ ';
 #use XMLTV::Capabilities qw/baseline manualconfig cache/;
 use XMLTV::Capabilities qw/baseline manualconfig/;
@@ -537,7 +539,7 @@ sub trim {
 #***************************************************************************
 if ($mode eq 'configure') {
   XMLTV::Config_file::check_no_overwrite($config_file);
-  open(CONF, ">$config_file") or die "Cannot write to $config_file: $!";
+  open(CONF, ">$config_file",'>:utf8') or die "Cannot write to $config_file: $!";
 
   #my $bar = new XMLTV::ProgressBar('getting channel lists', scalar grep { $_ } @gtwant) if not $opt_quiet;
   my %channels_for;
@@ -665,7 +667,7 @@ if ($mode eq 'grab') {
 #***************************************************************************
 my %w_args;
 if (defined $opt_output) {
-  my $fh = new IO::File(">$opt_output");
+  my $fh = new IO::File("$opt_output",'>:utf8');
   die "cannot write to $opt_output: $!" if not defined $fh;
   $w_args{OUTPUT} = $fh;
 }
@@ -708,7 +710,6 @@ if ($mode eq 'list-channels') {
     my $ch_xid = $channel_prefix.$ch_did.$channel_postfix;
     $writer->write_channel({ id => $ch_xid,
                              'display-name' => [ [ $channels{$ch_did}{name} ] ],
-                             #                                                                               'icon' => [{src=>$ROOT_URL.$channels{$ch_did}{icon}}] })
                              'icon' => [{src=> $channels{$ch_did}{icon} }] })
       unless $seen{$ch_xid}++;
   }
@@ -735,7 +736,7 @@ foreach (@config_lines) {
   # Here we store the Channel name with the ID in the config file, as the XMLTV id = Website ID
   if (/^channel:?\s+(\S+)\s+([^\#]+);([^\#]+)/) {
     $chid = $1;
-    $chname = $2;
+    $chname = decode('UTF-8',$2);
     $chicon = $3;
     $chname =~ s/\s*$//;
     if($chid =~ /(\d+):(.*)/) {

--- a/tv_grab_fr_telerama
+++ b/tv_grab_fr_telerama
@@ -670,7 +670,7 @@ if (defined $opt_output) {
   $w_args{OUTPUT} = $fh;
 }
 
-$w_args{ENCODING} = 'utf-8';
+$w_args{encoding} = 'UTF-8';
 #$w_args{days} = $opt_days;
 #$w_args{offset} = $opt_offset;
 #$w_args{cutoff} = "000000";
@@ -967,11 +967,38 @@ sub process_channel_grid_page( $$$$$$ ) {
   }
 
   #print "Getting URL : ".$url."\n";
-  my @lines = @{ $json_hash->{'donnees'} };
 
+  # flag overlapping
+  # check all, starting at end
+  my $nb = scalar @{ $json_hash->{'donnees'} };
+  my $start = 0;
+  $json_hash->{'donnees'}[$nb-1]{'overlap'} = 0;
+  for (my $i=$nb-1;$i>=1;$i--) {
+    my $stop_prev = $json_hash->{'donnees'}[$i-1]{'horaire'}{'fin'};
+    $stop_prev  =~ tr/:\$\ -//d;
+    if($json_hash->{'donnees'}[$i]{'overlap'} != 1) {
+      $start = $json_hash->{'donnees'}[$i]{'horaire'}{'debut'};
+      $start =~ tr/:\$\ -//d;
+    }
+    if($stop_prev > $start) {
+      $json_hash->{'donnees'}[$i-1]{'overlap'} = 1;
+    } else {
+      $json_hash->{'donnees'}[$i-1]{'overlap'} = 0;
+    }
+  }
+  # if last programme start >= 06:00:00 flag it
+  # to avoid duplicate between day and day+1
+  if($json_hash->{'donnees'}[$nb-1]{'horaire'}{'debut'} =~ m/(\d+):\d+:\d+$/) {
+    if( $1 > 6) { $json_hash->{'donnees'}[$nb-1]{'overlap'} = 1; }
+  }
+
+  my @lines = @{ $json_hash->{'donnees'} };
   foreach my $line ( @lines ) {
     # debug_print "Found line : " . $line . "\n";
     # print STDERR Dumper($line);
+
+    # skip overlaping and duplicate
+    if($line->{'overlap'}) { next;}
 
     $chid = $line->{'id_chaine'};
 
@@ -1096,25 +1123,13 @@ sub process_channel_grid_page( $$$$$$ ) {
     }
     $prog{'date'} = $line->{'annee_realisation'} if ($line->{'annee_realisation'});
     $prog{country} = [[$line->{'libelle_nationalite'}]] if ($line->{'libelle_nationalite'});
-    if ($line->{'flags'}{'est_ar16x9'}) {
-      $prog{video}{aspect} = "16:9";
-    } elsif ($line->{'flags'}{'est_ar4x3'}) {
-      $prog{video}{aspect} = "4:3";
-    }
     $prog{'audio'}{stereo} = "bilingual" if ($line->{'flags'}{'est_vm'});
     #$prog{title_orig} = $line->{'titre_original'} if ($line->{'titre_original'});
 
     $crypted = 0 if ($line->{'flags'}{'est_clair'});
     $prog{subtitles} = [ { type => 'onscreen', language => ['fr'] } ] if ($line->{'flags'}{'est_vost'});
-    $prog{video}{quality} = "HDTV" if ($line->{'flags'}{'est_hd'});
     $prog{premiere} = [] if ($line->{'flags'}{'est_inedit'});
     $prog{'previously-shown'} = {} if ($line->{'flags'}{'est_redif'});
-    if ($line->{'flags'}{'est_stereo'}) {
-      $prog{'audio'}{stereo} = "stereo";
-    } elsif ($line->{'flags'}{'est_dolby'}) {
-      $prog{'audio'}{stereo} = "dolby";
-    }
-    $prog{showview} = $line->{'showview'};
 
     # skip crypted shows for Canal+ or Paris Premiere
     if ( ($chname =~ m/Canal+/) && ($crypted == 1) ) {

--- a/tv_grab_fr_telerama
+++ b/tv_grab_fr_telerama
@@ -471,7 +471,7 @@ sub get_channels( $ );
 sub return_other_channels( );
 sub build_other_channel_filename();
 sub get_more_channel_icon( $ );
-sub process_channel_grid_page( $$$$$ );
+sub process_channel_grid_page( $$$$$$ );
 sub debug_print( @ );
 sub get_page( $$ );
 
@@ -726,7 +726,7 @@ die if $mode ne 'grab';
 #***************************************************************************
 # Build the working list of channel name/channel id
 #***************************************************************************
-my (%channels, $chicon, $chid, $chname);
+my (%channels, $chicon, $chid, $chname, $chid_name);
 my $line_num = 1;
 foreach (@config_lines) {
   ++ $line_num;
@@ -738,7 +738,13 @@ foreach (@config_lines) {
     $chname = $2;
     $chicon = $3;
     $chname =~ s/\s*$//;
-    $channels{$line_num} = {'chid'=>$chid, 'name'=>$chname, 'icon'=>$chicon};
+    if($chid =~ /(\d+):(.*)/) {
+      $chid = $1;
+      $chid_name = $2;
+    } else {
+      $chid_name = '';
+    }
+    $channels{$line_num} = {'chid'=>$chid, 'name'=>$chname, 'icon'=>$chicon, 'chid_name'=>$chid_name};
   } else {
     warn "$config_file:$line_num: bad line $_\n";
   }
@@ -759,8 +765,14 @@ foreach $ind (sort { $a <=> $b } keys %channels) {
   my $i;
   my $dayoff;
   my $json_name = "";
+  my $chid_name = "";
 
-  $writer->write_channel({ id => $channel_prefix.$chid.$channel_postfix, 'display-name' => [[$channels{$ind}{name}]], 'icon' => [{src=>$channels{$ind}{icon}}]});
+  if($channels{$ind}{chid_name} ne '') {
+    $chid_name = $channels{$ind}{chid_name};
+  } else {
+    $chid_name = $channel_prefix.$chid.$channel_postfix;
+  }
+  $writer->write_channel({ id => $chid_name, 'display-name' => [[$channels{$ind}{name}]], 'icon' => [{src=>$channels{$ind}{icon}}]});
   if ( $opt_per_days ) {
     for ($i=$opt_offset; $i < $opt_offset+$opt_days; $i++ ) {
       #debug_print( "i: $i\n");
@@ -776,12 +788,12 @@ foreach $ind (sort { $a <=> $b } keys %channels) {
         # debug_print($json_name."\n");
       }
 
-      push @to_get, [ $url, $chid, $i, $json_name ];
+      push @to_get, [ $url, $chid, $i, $json_name, $chid_name ];
     }
   } else {
     foreach (@offsets) {
       #$url = $GRID_BY_CHANNEL . "$chid&h=$_";
-      push @to_get, [ $url, $chid, $_ ];
+      push @to_get, [ $url, $chid, $_, $chid_name ];
     }
   }
 }
@@ -791,8 +803,8 @@ my $bar = new XMLTV::ProgressBar('getting listings', scalar @to_get)  if not $op
 Date_Init('SetDate=now,UTC');
 
 foreach (@to_get) {
-  my ($url, $chid, $slot, $jsname) = @$_;
-  process_channel_grid_page($writer, $chid, $url, $slot, $jsname);
+  my ($url, $chid, $slot, $jsname, $chid_name) = @$_;
+  process_channel_grid_page($writer, $chid, $url, $slot, $jsname, $chid_name);
   update $bar if not $opt_quiet;
 }
 
@@ -941,8 +953,8 @@ sub get_page_json( $$ ) {
   return $json_hash;
 }
 
-sub process_channel_grid_page( $$$$$ ) {
-  my ($writer, $chid, $url, $slot, $jsname) = @_;
+sub process_channel_grid_page( $$$$$$ ) {
+  my ($writer, $chid, $url, $slot, $jsname, $chid_name) = @_;
 
   if (!@genres) {
     get_channels("categories.json");
@@ -995,7 +1007,7 @@ sub process_channel_grid_page( $$$$$ ) {
 
     $startdate = utc_offset( $startdate, "+0100");
     $enddate  = utc_offset( $enddate , "+0100");
-    my %prog = (channel  => $channel_prefix.$chid.$channel_postfix,
+    my %prog = (channel  => $chid_name,
                 title       => [ [ $line->{'titre'} ] ], # lang unknown
                 start       => $startdate,
                 stop         => $enddate


### PR DESCRIPTION
Hi,

This PR allows to have custom channel id

For exemple, currently with defaut conf file :
`channel 4 France 2;http://television.telerama.fr/sites/tr_master/files/sheet_media/tv/500x500/4.png`

Channel id will be C4.api.telerama.fr :
` <channel id="C4.api.telerama.fr">
    <display-name>France 2</display-name>
    <icon src="http://television.telerama.fr/sites/tr_master/files/sheet_media/tv/500x500/4.png" />
  </channel>`

With this PR you can specify the channel id (no space allowed) by using  `:my_custom_id` (no space allowed) after api chid.
For exemple :
`channel 4:France2.fr France 2;http://television.telerama.fr/sites/tr_master/files/sheet_media/tv/500x500/4.png`

Channel id will be France2.fr
`<channel id="France2.fr">
    <display-name>France 2</display-name>
    <icon src="http://television.telerama.fr/sites/tr_master/files/sheet_media/tv/500x500/4.png" />
  </channel>`

If you don't use `:my_custom_id` after api chid, the result remains unchanged.

Thanks.