### PR TITLE
Open conf_file syntax error in configuration mode

### DIFF
--- a/tv_grab_fr_telerama
+++ b/tv_grab_fr_telerama
@@ -543,7 +543,7 @@ sub trim {
 #***************************************************************************
 if ($mode eq 'configure') {
   XMLTV::Config_file::check_no_overwrite($config_file);
-  open(CONF, ">$config_file",'>:utf8') or die "Cannot write to $config_file: $!";
+  open(CONF, '>:utf8', $config_file) or die "Cannot write to $config_file: $!";
 
   #my $bar = new XMLTV::ProgressBar('getting channel lists', scalar grep { $_ } @gtwant) if not $opt_quiet;
   my %channels_for;


### PR DESCRIPTION
The perl open method was not correctly used : mode and filename method's parameters mixed.