### PR TITLE
Improve program cache

### DIFF
--- a/tv_grab_fr_telerama
+++ b/tv_grab_fr_telerama
@@ -457,7 +457,7 @@ my $CHANNEL_PROGRAMME_PAGE = '/tlr/v1/free-android-tablet/element';
 my $ROOT_URL  = 'https://apps.telerama.fr';
 
 my %stats;
-my $emissions_cache = 0;
+my $emissions_cache = 1;
 $stats{cache_casting} = 0;
 $stats{api}{total} = 0;
 

--- a/tv_grab_fr_telerama
+++ b/tv_grab_fr_telerama
@@ -957,13 +957,13 @@ sub grab_day_channel($$$$$$) {
       if ($save_json) { $jsname_programme = mkjsonname("", { "id_programme" => $line->{'id'}}); }
       my $json_p;
       # try to use emissions cache
-      if(exists $emissions{$line->{id}} && $emissions_cache) {
+      if($id && exists $emissions{$id} && $emissions_cache) {
         #use cache
         $stats{cache_casting}++;
-        $json_p = $emissions{$line->{id}};
+        $json_p = $emissions{$id};
       } else {
         $json_p = get_page_json('casting', $url_programme, $jsname_programme);
-        $emissions{$line->{id}} = $json_p if $emissions_cache;
+        $emissions{$id} = $json_p if ($emissions_cache && $id);
       }
 
       my $content = $json_p->{'templates'}->{'raw_content'}->{'content'};


### PR DESCRIPTION
**Short description**

If you look closer at json of the new Télarama API, you will see that the `deeplink` values, when the same program is rerun several times, are very similar.

In fact it seems that in `deeplink`, the value of  `id` would do a better job as a key to to cache program, than the `program_id` value.

So this PR use it instead of `program_id` value in the _program cache_.

**Detailed example**

For exemple here are the same program on TMC, the 2025-08-25 and the 2025-08-26.

2025-08-25 :
```json
{
    "has_rating": false,
    "title": "Madame est servie",
    "start_date": "2025-08-25T10:05:00.000+02:00",
    "end_date": "2025-08-25T10:35:00.000+02:00",
    "type": "serie",
    "filter_type": "serie",
    "is_inedit": false,
    "is_replay": true,
    "is_live": false,
    "illustration": {
        "url": "https://focus.telerama.fr/{{width}}x{{height}}/2025/08/08/90ca6f3a3c4b4754b319eddd63f7d839.jpg",
        "ratio": 1.5
    },
    "id": "13255352",
    "flags": [
        "haute-definition",
        "teletexte"
    ],
    "deeplink": "tlrm://element?program_id=13255352&id=%2Ftele%2Fserie%2Fmadame-est-servie-1-86991525-saison3-episode22.php&source=tv_program_grid"
}
```

2025-05-26:
```json
{
    "has_rating": false,
    "title": "Madame est servie",
    "start_date": "2025-08-26T09:05:00.000+02:00",
    "end_date": "2025-08-26T09:35:00.000+02:00",
    "type": "serie",
    "filter_type": "serie",
    "is_inedit": false,
    "is_replay": true,
    "is_live": false,
    "illustration": {
        "url": "https://focus.telerama.fr/{{width}}x{{height}}/2025/08/08/90ca6f3a3c4b4754b319eddd63f7d839.jpg",
        "ratio": 1.5
    },
    "id": "13269106",
    "flags": [
        "haute-definition",
        "teletexte"
    ],
    "deeplink": "tlrm://element?program_id=13269106&id=%2Ftele%2Fserie%2Fmadame-est-servie-1-86991525-saison3-episode22.php&source=tv_program_grid"
}
```
You can see that the `deeplink` values are very similar: the only difference is the `program_id` 
- `tlrm://element?program_id=13255352&id=%2Ftele%2Fserie%2Fmadame-est-servie-1-86991525-saison3-episode22.php&source=tv_program_grid` and 
- `tlrm://element?program_id=13269106&id=%2Ftele%2Fserie%2Fmadame-est-servie-1-86991525-saison3-episode22.php&source=tv_program_grid`

Both _element url_ refer to the same page (in fact `program_id` doesn't matter):
-  `curl 'https://apps.telerama.fr/tlr/v1/free-android-phone/element?program_id=13255352&id=%2Ftele%2Fserie%2Fmadame-est-servie-1-86991525-saison3-episode22.php&source=tv_program_grid'`
- `curl 'https://apps.telerama.fr/tlr/v1/free-android-phone/element?program_id=13269106&id=%2Ftele%2Fserie%2Fmadame-est-servie-1-86991525-saison3-episode22.php&source=tv_program_grid'`
- `curl 'https://apps.telerama.fr/tlr/v1/free-android-phone/element?id=%2Ftele%2Fserie%2Fmadame-est-servie-1-86991525-saison3-episode22.php'`

all return the same json.

So if we use the `deeplink` `id` as key in program cache, when a same program is rerun several time, we will use cached value for each rerun.
